### PR TITLE
Cmake and interface extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_policy(SET CMP0048 NEW)  # project_VERSION* variables populated from project(... VERSION x.x.x) string
-project(psi4_cct3
+project(cct3
         VERSION 0.1
         LANGUAGES CXX Fortran)
-set(psi4_cct3_AUTHORS      "Emiliano Deustua")
-set(psi4_cct3_DESCRIPTION  "Active-space coupled-cluster CCSDt and non-iterative corrections to CCSDt defining the CC(t;3) approach plugin to Psi4")
-set(psi4_cct3_URL          "https://github.com/piecuch-group/psi4_cct3")
-set(psi4_cct3_LICENSE      "LGPL-3.0")
+set(cct3_AUTHORS      "Emiliano Deustua")
+set(cct3_DESCRIPTION  "Active-space coupled-cluster CCSDt and non-iterative corrections to CCSDt defining the CC(t;3) approach plugin to Psi4")
+set(cct3_URL          "https://github.com/piecuch-group/cct3")
+set(cct3_LICENSE      "LGPL-3.0")
 
 cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -21,7 +21,7 @@ find_package(psi4 1.1 REQUIRED)
 set(PN ${PROJECT_NAME})
 
 # PYMOD_INSTALL_LIBDIR If set, installs python modules to
-#                      ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4_cct3 rather than
+#                      ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/cct3 rather than
 #                      the default read off parent Psi4
 
 #   install alongside psi4 module by default, but overrideable
@@ -57,7 +57,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -extend-source 132")
 endif()
 
-add_psi4_plugin(psi4_cct3
+add_psi4_plugin(cct3
     src/cct3.cc
     src/Cal_D3.f
     src/cc_utils.f
@@ -259,13 +259,13 @@ add_psi4_plugin(psi4_cct3
     src/wrapper_psi4.f90
 )
 
-target_link_libraries(psi4_cct3 PRIVATE ${LIBC_INTERJECT})
+target_link_libraries(cct3 PRIVATE ${LIBC_INTERJECT})
 
 configure_file(__init__.py.in __init__.py @ONLY)
 
 # <<<  Install  >>>
 
-install(TARGETS psi4_cct3
+install(TARGETS cct3
         EXPORT "${PN}Targets"
         LIBRARY DESTINATION ${PYMOD_INSTALL_FULLDIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,52 +1,292 @@
-#
-# @BEGIN LICENSE
-#
-# moint by Psi4 Developer, a plugin to:
-#
-# Psi4: an open-source quantum chemistry software package
-#
-# Copyright (c) 2007-2017 The Psi4 Developers.
-#
-# The copyrights for code used from other parties are included in
-# the corresponding files.
-#
-# This file is part of Psi4.
-#
-# Psi4 is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, version 3.
-#
-# Psi4 is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License along
-# with Psi4; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#
-# @END LICENSE
-#
+cmake_policy(SET CMP0048 NEW)  # project_VERSION* variables populated from project(... VERSION x.x.x) string
+project(psi4_cct3
+        VERSION 0.1
+        LANGUAGES CXX Fortran)
+set(psi4_cct3_AUTHORS      "Emiliano Deustua")
+set(psi4_cct3_DESCRIPTION  "Active-space coupled-cluster CCSDt and non-iterative corrections to CCSDt defining the CC(t;3) approach plugin to Psi4")
+set(psi4_cct3_URL          "https://github.com/piecuch-group/psi4_cct3")
+set(psi4_cct3_LICENSE      "LGPL-3.0")
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-project(psi4-cct3 CXX Fortran)
+# <<<  Prepare  >>>
 
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(TargetOpenMP_FIND_COMPONENTS "CXX Fortran")
 find_package(psi4 1.1 REQUIRED)
+
+set(PN ${PROJECT_NAME})
+
+# PYMOD_INSTALL_LIBDIR If set, installs python modules to
+#                      ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/psi4_cct3 rather than
+#                      the default read off parent Psi4
+
+#   install alongside psi4 module by default, but overrideable
+get_filename_component(psi4_CMAKE_INSTALL_PREFIX ${psi4_INCLUDE_DIR} DIRECTORY)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX ${psi4_CMAKE_INSTALL_PREFIX} CACHE PATH "Install path" FORCE)
+endif()
+message(STATUS "Plugin install prefix: ${CMAKE_INSTALL_PREFIX}")
+
+if(PYMOD_INSTALL_LIBDIR)
+    set(PYMOD_INSTALL_FULLDIR "${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/${PN}")
+else()
+    file(RELATIVE_PATH _tmp ${psi4_CMAKE_INSTALL_PREFIX} ${psi4_LIBRARY})
+    #   e.g., _tmp = lib/psi4/core.so
+    get_filename_component(_tmp2 ${_tmp} DIRECTORY)
+    get_filename_component(_tmp3 ${_tmp2} DIRECTORY)
+    set(PYMOD_INSTALL_FULLDIR "${_tmp3}/${PN}")
+endif()
+message(STATUS "Plugin module install: ${PYMOD_INSTALL_FULLDIR}")
+
+
+include(custom_static_library)
+
+# <<<  Build  >>>
 
 # Debug
 # set(CMAKE_Fortran_FLAGS  "${CMAKE_CXX_FLAGS} -fcheck=all -g -fbacktrace -ffixed-line-length-132" )
 
-set(CMAKE_Fortran_FLAGS  "${CMAKE_CXX_FLAGS} -ffixed-line-length-132" )
+if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffixed-line-length-132")
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -extend-source 132")
+endif()
 
-file(GLOB CCT3_F_SRC
-        "src/*.f"
-        "src/hbar/*.f"
-        "src/cc/*.f"
-        "src/ccsd/*.f"
-        "src/lcc/*.f"
-        "src/*.f90"
-        "src/*.F90"
-        )
+add_psi4_plugin(psi4_cct3
+    src/cct3.cc
+    src/Cal_D3.f
+    src/cc_utils.f
+    src/dgemm.f
+    src/energy.f
+    src/reorder_old1.f
+    src/sum_old1.f
+    src/update_ccsd.f
+    src/update_clusters.f
+    src/update_lambdas.f
+    src/hbar/HBar0A2A.f
+    src/hbar/HBar0A2C.f
+    src/hbar/HBar0A4A.f
+    src/hbar/HBar0A4C.f
+    src/hbar/HBar0A4E.f
+    src/hbar/HBar1A1A.f
+    src/hbar/HBar1A3A0.f
+    src/hbar/HBar1A3A.f
+    src/hbar/HBar1A3C0.f
+    src/hbar/HBar1A3C.f
+    src/hbar/HBar1B1B.f
+    src/hbar/HBar1B3B0.f
+    src/hbar/HBar1B3B.f
+    src/hbar/HBar1B3D0.f
+    src/hbar/HBar1B3D.f
+    src/hbar/HBar2A0A.f
+    src/hbar/HBar2A2A.f
+    src/hbar/HBar2A2C.f
+    src/hbar/HBar2B2B0.f
+    src/hbar/HBar2B2B.f
+    src/hbar/HBar2C0A.f
+    src/hbar/HBar2C2A.f
+    src/hbar/HBar2C2C.f
+    src/hbar/HBar3A1A0.f
+    src/hbar/HBar3A1A.f
+    src/hbar/HBar3B1B0.f
+    src/hbar/HBar3B1B.f
+    src/hbar/HBar3C1A0.f
+    src/hbar/HBar3C1A.f
+    src/hbar/HBar3D1B0.f
+    src/hbar/HBar3D1B.f
+    src/hbar/HBar4A0A.f
+    src/hbar/HBar4C0A.f
+    src/hbar/HBar4E0A.f
+    src/cc/t1A00_update.f
+    src/cc/t1A01_update.f
+    src/cc/t1A10_update.f
+    src/cc/t1A11_update.f
+    src/cc/t1A_update.f
+    src/cc/t1B00_update.f
+    src/cc/t1B01_update.f
+    src/cc/t1B10_update.f
+    src/cc/t1B11_update.f
+    src/cc/t1B_update.f
+    src/cc/t2A0000_update.f
+    src/cc/t2A0010_update.f
+    src/cc/t2A0011_update.f
+    src/cc/t2A1000_update.f
+    src/cc/t2A1010_update.f
+    src/cc/t2A1011_update.f
+    src/cc/t2A1100_update.f
+    src/cc/t2A1110_update.f
+    src/cc/t2A1111_update.f
+    src/cc/t2A_update1.f
+    src/cc/t2A_update.f
+    src/cc/t2B0000_update.f
+    src/cc/t2B0001_update.f
+    src/cc/t2B0010_update.f
+    src/cc/t2B0011_update.f
+    src/cc/t2B0100_update.f
+    src/cc/t2B0101_update.f
+    src/cc/t2B0110_update.f
+    src/cc/t2B0111_update.f
+    src/cc/t2B1000_update.f
+    src/cc/t2B1001_update.f
+    src/cc/t2B1010_update.f
+    src/cc/t2B1011_update.f
+    src/cc/t2B1100_update.f
+    src/cc/t2B1101_update.f
+    src/cc/t2B1110_update.f
+    src/cc/t2B1111_update.f
+    src/cc/t2B_update1.f
+    src/cc/t2B_update.f
+    src/cc/t2C0000_update.f
+    src/cc/t2C0010_update.f
+    src/cc/t2C0011_update.f
+    src/cc/t2C1000_update.f
+    src/cc/t2C1010_update.f
+    src/cc/t2C1011_update.f
+    src/cc/t2C1100_update.f
+    src/cc/t2C1110_update.f
+    src/cc/t2C1111_update.f
+    src/cc/t2C_update1.f
+    src/cc/t2C_update.f
+    src/cc/t3A100100_update.f
+    src/cc/t3A100110_update.f
+    src/cc/t3A100111_update.f
+    src/cc/t3A110100_update.f
+    src/cc/t3A110110_update.f
+    src/cc/t3A110111_update.f
+    src/cc/t3A111100_update.f
+    src/cc/t3A111110_update.f
+    src/cc/t3A111111_update.f
+    src/cc/t3AB_update.f
+    src/cc/t3A_update.f
+    src/cc/t3B001001_update.f
+    src/cc/t3B001100_update.f
+    src/cc/t3B001101_update.f
+    src/cc/t3B001110_update.f
+    src/cc/t3B001111_update.f
+    src/cc/t3B100001_update.f
+    src/cc/t3B100100_update.f
+    src/cc/t3B100101_update.f
+    src/cc/t3B100110_update.f
+    src/cc/t3B100111_update.f
+    src/cc/t3B101001_update.f
+    src/cc/t3B101100_update.f
+    src/cc/t3B101101_update.f
+    src/cc/t3B101110_update.f
+    src/cc/t3B101111_update.f
+    src/cc/t3B110001_update.f
+    src/cc/t3B110100_update.f
+    src/cc/t3B110101_update.f
+    src/cc/t3B110110_update.f
+    src/cc/t3B110111_update.f
+    src/cc/t3B111001_update.f
+    src/cc/t3B111100_update.f
+    src/cc/t3B111101_update.f
+    src/cc/t3B111110_update.f
+    src/cc/t3B111111_update.f
+    src/cc/t3BC_update.f
+    src/cc/t3B_update.f
+    src/cc/t3C010010_update.f
+    src/cc/t3C010011_update.f
+    src/cc/t3C010100_update.f
+    src/cc/t3C010110_update.f
+    src/cc/t3C010111_update.f
+    src/cc/t3C011010_update.f
+    src/cc/t3C011011_update.f
+    src/cc/t3C011100_update.f
+    src/cc/t3C011110_update.f
+    src/cc/t3C011111_update.f
+    src/cc/t3C100010_update.f
+    src/cc/t3C100011_update.f
+    src/cc/t3C100100_update.f
+    src/cc/t3C100110_update.f
+    src/cc/t3C100111_update.f
+    src/cc/t3C110010_update.f
+    src/cc/t3C110011_update.f
+    src/cc/t3C110100_update.f
+    src/cc/t3C110110_update.f
+    src/cc/t3C110111_update.f
+    src/cc/t3C111010_update.f
+    src/cc/t3C111011_update.f
+    src/cc/t3C111100_update.f
+    src/cc/t3C111110_update.f
+    src/cc/t3C111111_update.f
+    src/cc/t3CD_update.f
+    src/cc/t3C_update.f
+    src/cc/t3D100100_update.f
+    src/cc/t3D100110_update.f
+    src/cc/t3D100111_update.f
+    src/cc/t3D110100_update.f
+    src/cc/t3D110110_update.f
+    src/cc/t3D110111_update.f
+    src/cc/t3D111100_update.f
+    src/cc/t3D111110_update.f
+    src/cc/t3D111111_update.f
+    src/cc/t3D_update.f
+    src/ccsd/t1A_update.f
+    src/ccsd/t1B_update.f
+    src/ccsd/t2A_update1.f
+    src/ccsd/t2A_update.f
+    src/ccsd/t2B_update1.f
+    src/ccsd/t2B_update.f
+    src/ccsd/t2C_update1.f
+    src/ccsd/t2C_update.f
+    src/lcc/L1A_update.f
+    src/lcc/L1B_update.f
+    src/lcc/L2A_update.f
+    src/lcc/L2B_update.f
+    src/lcc/L2C_update.f
+    src/lcc/L3A_update.f
+    src/lcc/L3B_update.f
+    src/lcc/L3C_update.f
+    src/lcc/L3D_update.f
+    src/lcc/L_input.f
+    src/lcc/L_update.f
+    src/const.f90
+    src/correction.f90
+    src/diis.f90
+    src/driver.f90
+    src/hbar.f90
+    src/integrals.f90
+    src/printing.f90
+    src/solver.f90
+    src/system.f90
+    src/utils.f90
+    src/wrapper_psi4.f90
+)
 
-add_psi4_plugin(psi4_cct3 src/cct3.cc ${CCT3_F_SRC})
+target_link_libraries(psi4_cct3 PRIVATE ${LIBC_INTERJECT})
+
+configure_file(__init__.py.in __init__.py @ONLY)
+
+# <<<  Install  >>>
+
+install(TARGETS psi4_cct3
+        EXPORT "${PN}Targets"
+        LIBRARY DESTINATION ${PYMOD_INSTALL_FULLDIR})
+
+install(FILES pymodule.py LICENSE README.rst
+              ${CMAKE_CURRENT_BINARY_DIR}/__init__.py
+        DESTINATION ${PYMOD_INSTALL_FULLDIR})
+
+# <<< Export Config >>>
+
+# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
+set(CMAKECONFIG_INSTALL_DIR "share/cmake/${PN}")
+configure_package_config_file(cmake/${PN}Config.cmake.in
+                              "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
+                              INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
+                                 VERSION ${${PN}_VERSION}
+                                 COMPATIBILITY AnyNewerVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
+        DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+install(EXPORT "${PN}Targets"
+        NAMESPACE "${PN}::"
+        DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,13 @@ install(FILES pymodule.py LICENSE README.rst
               ${CMAKE_CURRENT_BINARY_DIR}/__init__.py
         DESTINATION ${PYMOD_INSTALL_FULLDIR})
 
+install(DIRECTORY tests/
+        DESTINATION ${PYMOD_INSTALL_FULLDIR}/tests
+        FILES_MATCHING PATTERN "conftest.py"
+                       PATTERN "test_*.py"
+        PATTERN ".pytest_cache" EXCLUDE
+        PATTERN "__pycache__" EXCLUDE)
+
 # <<< Export Config >>>
 
 # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".

--- a/__init__.py.in
+++ b/__init__.py.in
@@ -1,11 +1,11 @@
 #
 # @BEGIN LICENSE
 #
-# mointt by Psi4 Developer, a plugin to:
+# psi4_cct3 by Emiliano Deustua, a plugin to:
 #
 # Psi4: an open-source quantum chemistry software package
 #
-# Copyright (c) 2007-2017 The Psi4 Developers.
+# Copyright (c) 2007-2020 The Psi4 Developers.
 #
 # The copyrights for code used from other parties are included in
 # the corresponding files.
@@ -32,10 +32,18 @@
 
 """
 __version__ = '0.1'
-__author__  = 'Psi4 Developer'
+__author__  = "Emiliano Deustua"
+
+# Load Psi4
+psi4_sys_path = '@psi4_SYS_PATH@'
+import sys
+sys.path.append(psi4_sys_path)
 
 # Load Python modules
 from .pymodule import *
+
+# Load C++ Pybind11 plugin
+#from .psi4_cct3 import *
 
 # Load C++ plugin
 import os
@@ -43,4 +51,3 @@ import psi4
 plugdir = os.path.split(os.path.abspath(__file__))[0]
 sofile = plugdir + '/' + os.path.split(plugdir)[1] + '.so'
 psi4.core.plugin_load(sofile)
-

--- a/cmake/cct3Config.cmake.in
+++ b/cmake/cct3Config.cmake.in
@@ -1,13 +1,13 @@
-# psi4_cct3Config.cmake
+# cct3Config.cmake
 # ---------------------
 #
-# psi4_cct3 cmake module.
+# cct3 cmake module.
 # This module sets the following variables in your project::
 #
-#   psi4_cct3_FOUND - true if psi4_cct3 and all required components found on the system
-#   psi4_cct3_VERSION - psi4_cct3 version in format Major.Minor.Release
-#   psi4_cct3_LIBRARIES - psi4_cct3 library to link against.
-#   psi4_cct3_LIBRARY - same as LIBRARIES
+#   cct3_FOUND - true if cct3 and all required components found on the system
+#   cct3_VERSION - cct3 version in format Major.Minor.Release
+#   cct3_LIBRARIES - cct3 library to link against.
+#   cct3_LIBRARY - same as LIBRARIES
 #
 #
 # Available components: None
@@ -15,29 +15,29 @@
 #
 # Exported targets::
 #
-# If psi4_cct3 is found, this module defines the following :prop_tgt:`IMPORTED`
+# If cct3 is found, this module defines the following :prop_tgt:`IMPORTED`
 # target. ::
 #
-#   psi4_cct3::psi4_cct3 - the main psi4_cct3 library
+#   cct3::cct3 - the main cct3 library
 #
 #
 # Suggested usage::
 #
-#   find_package(psi4_cct3)
-#   find_package(psi4_cct3 0.1 EXACT CONFIG REQUIRED)
+#   find_package(cct3)
+#   find_package(cct3 0.1 EXACT CONFIG REQUIRED)
 #
 #
 # The following variables can be set to guide the search for this package::
 #
-#   psi4_cct3_DIR - CMake variable, set to directory containing this Config file
+#   cct3_DIR - CMake variable, set to directory containing this Config file
 #   CMAKE_PREFIX_PATH - CMake variable, set to root directory of this package
 ##   PATH - environment variable, set to bin directory of this package
-#   CMAKE_DISABLE_FIND_PACKAGE_psi4_cct3 - CMake variable, disables
-#     find_package(psi4_cct3) when not REQUIRED, perhaps to force internal build
+#   CMAKE_DISABLE_FIND_PACKAGE_cct3 - CMake variable, disables
+#     find_package(cct3) when not REQUIRED, perhaps to force internal build
 
 @PACKAGE_INIT@
 
-set(PN psi4_cct3)
+set(PN cct3)
 
 check_required_components(${PN})
 
@@ -45,10 +45,10 @@ check_required_components(${PN})
 # Don't include targets if this file is being picked up by another
 # project which has already built this as a subproject
 #-----------------------------------------------------------------------------
-if(NOT TARGET ${PN}::psi4_cct3)
+if(NOT TARGET ${PN}::cct3)
     include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
 
-    get_property(_loc TARGET ${PN}::psi4_cct3 PROPERTY LOCATION)
+    get_property(_loc TARGET ${PN}::cct3 PROPERTY LOCATION)
     set(${PN}_LIBRARY ${_loc})
     set(${PN}_LIBRARIES ${_loc})
 endif()

--- a/cmake/psi4_cct3Config.cmake.in
+++ b/cmake/psi4_cct3Config.cmake.in
@@ -1,0 +1,55 @@
+# psi4_cct3Config.cmake
+# ---------------------
+#
+# psi4_cct3 cmake module.
+# This module sets the following variables in your project::
+#
+#   psi4_cct3_FOUND - true if psi4_cct3 and all required components found on the system
+#   psi4_cct3_VERSION - psi4_cct3 version in format Major.Minor.Release
+#   psi4_cct3_LIBRARIES - psi4_cct3 library to link against.
+#   psi4_cct3_LIBRARY - same as LIBRARIES
+#
+#
+# Available components: None
+#
+#
+# Exported targets::
+#
+# If psi4_cct3 is found, this module defines the following :prop_tgt:`IMPORTED`
+# target. ::
+#
+#   psi4_cct3::psi4_cct3 - the main psi4_cct3 library
+#
+#
+# Suggested usage::
+#
+#   find_package(psi4_cct3)
+#   find_package(psi4_cct3 0.1 EXACT CONFIG REQUIRED)
+#
+#
+# The following variables can be set to guide the search for this package::
+#
+#   psi4_cct3_DIR - CMake variable, set to directory containing this Config file
+#   CMAKE_PREFIX_PATH - CMake variable, set to root directory of this package
+##   PATH - environment variable, set to bin directory of this package
+#   CMAKE_DISABLE_FIND_PACKAGE_psi4_cct3 - CMake variable, disables
+#     find_package(psi4_cct3) when not REQUIRED, perhaps to force internal build
+
+@PACKAGE_INIT@
+
+set(PN psi4_cct3)
+
+check_required_components(${PN})
+
+#-----------------------------------------------------------------------------
+# Don't include targets if this file is being picked up by another
+# project which has already built this as a subproject
+#-----------------------------------------------------------------------------
+if(NOT TARGET ${PN}::psi4_cct3)
+    include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
+
+    get_property(_loc TARGET ${PN}::psi4_cct3 PROPERTY LOCATION)
+    set(${PN}_LIBRARY ${_loc})
+    set(${PN}_LIBRARIES ${_loc})
+endif()
+

--- a/examples/H8-0.1.dat
+++ b/examples/H8-0.1.dat
@@ -1,8 +1,7 @@
-
 # PYTHONPATH must include directory above plugin directory.
 #     Define either externally or here, then import plugin.
-sys.path.insert(0, './..')
-import psi4_cct3
+# sys.path.insert(0, './..')
+import cct3
 
 molecule {
     units bohr
@@ -33,7 +32,7 @@ basis {
 
 }
 
-set psi4_cct3 {
+set cct3 {
   froz 0
   act_occ 1
   act_unocc 1
@@ -41,5 +40,5 @@ set psi4_cct3 {
   calc_type 'CCT3'
 }
 
-ene = energy("psi4_cct3")
+ene = energy("cct3")
 compare_values(-4.220587742726, ene, 10, "CC(t;3) energy")

--- a/examples/H8-0.1.dat
+++ b/examples/H8-0.1.dat
@@ -41,4 +41,6 @@ set psi4_cct3 {
   calc_type 'CCT3'
 }
 
-energy('psi4_cct3')
+ene = energy("psi4_cct3")
+compare_values(-4.220587742726, item, 10, "CC(t;3) energy")
+

--- a/examples/H8-0.1.dat
+++ b/examples/H8-0.1.dat
@@ -42,5 +42,4 @@ set psi4_cct3 {
 }
 
 ene = energy("psi4_cct3")
-compare_values(-4.220587742726, item, 10, "CC(t;3) energy")
-
+compare_values(-4.220587742726, ene, 10, "CC(t;3) energy")

--- a/pymodule.py
+++ b/pymodule.py
@@ -1,11 +1,11 @@
 #
 # @BEGIN LICENSE
 #
-# moint by Psi4 Developer, a plugin to:
+# psi4_cct3 by Emiliano Deustua, a plugin to:
 #
 # Psi4: an open-source quantum chemistry software package
 #
-# Copyright (c) 2007-2017 The Psi4 Developers.
+# Copyright (c) 2007-2020 The Psi4 Developers.
 #
 # The copyrights for code used from other parties are included in
 # the corresponding files.
@@ -34,7 +34,7 @@ from psi4.driver.procrouting import proc_util
 
 def run_cct3(name, **kwargs):
     r"""Function encoding sequence of PSI module and plugin calls so that
-    moint can be called via :py:func:`~driver.energy`. For post-scf plugins.
+    psi4_cct3 can be called via :py:func:`~driver.energy`. For post-scf plugins.
 
     >>> energy('cct3')
 

--- a/pymodule.py
+++ b/pymodule.py
@@ -42,7 +42,20 @@ def run_cct3(name, **kwargs):
     lowername = name.lower()
     kwargs = p4util.kwargs_lower(kwargs)
 
+    optstash = p4util.OptionsState(
+        ['PSI4_CCT3', 'CALC_TYPE'])
+
     # Your plugin's psi4 run sequence goes here
+    if lowername == "psi4_cct3":
+        pass
+    elif lowername == "ccsd":
+        psi4.core.set_local_option("PSI4_CCT3", "CALC_TYPE", "CCSD")
+    elif lowername == "cr-cc(2,3)":
+        psi4.core.set_local_option("PSI4_CCT3", "CALC_TYPE", "CR-CC")
+    elif lowername == "ccsd_lct":  # CCSDt
+        psi4.core.set_local_option("PSI4_CCT3", "CALC_TYPE", "CCSD3A")
+    elif lowername == "cc(t;3)":
+        psi4.core.set_local_option("PSI4_CCT3", "CALC_TYPE", "CCT3")
 
     # Compute a SCF reference, a wavefunction is return which holds the molecule used, orbitals
     # Fock matrices, and more
@@ -61,9 +74,15 @@ def run_cct3(name, **kwargs):
     for k, v in cct3_wfn.variables().items():
         psi4.core.set_variable(k, v)
 
+    optstash.restore()
+
     return cct3_wfn
 
 
 # Integration with driver routines
 psi4.driver.procedures['energy']['psi4_cct3'] = run_cct3
+# CCSD is managed method. add `qc_module='cct3'` to access through this plugin
+psi4.driver.procedures['energy']['cr-cc(2,3)'] = run_cct3
+psi4.driver.procedures['energy']['ccsd_lct'] = run_cct3
+psi4.driver.procedures['energy']['cc(t;3)'] = run_cct3
 

--- a/pymodule.py
+++ b/pymodule.py
@@ -1,7 +1,7 @@
 #
 # @BEGIN LICENSE
 #
-# psi4_cct3 by Emiliano Deustua, a plugin to:
+# cct3 by Emiliano Deustua, a plugin to:
 #
 # Psi4: an open-source quantum chemistry software package
 #
@@ -34,7 +34,7 @@ from psi4.driver.procrouting import proc_util
 
 def run_cct3(name, **kwargs):
     r"""Function encoding sequence of PSI module and plugin calls so that
-    psi4_cct3 can be called via :py:func:`~driver.energy`. For post-scf plugins.
+    cct3 can be called via :py:func:`~driver.energy`. For post-scf plugins.
 
     >>> energy('cct3')
 
@@ -43,19 +43,19 @@ def run_cct3(name, **kwargs):
     kwargs = p4util.kwargs_lower(kwargs)
 
     optstash = p4util.OptionsState(
-        ['PSI4_CCT3', 'CALC_TYPE'])
+        ['CCT3', 'CALC_TYPE'])
 
     # Your plugin's psi4 run sequence goes here
-    if lowername == "psi4_cct3":
+    if lowername == "cct3":
         pass
     elif lowername == "ccsd":
-        psi4.core.set_local_option("PSI4_CCT3", "CALC_TYPE", "CCSD")
+        psi4.core.set_local_option("CCT3", "CALC_TYPE", "CCSD")
     elif lowername == "cr-cc(2,3)":
-        psi4.core.set_local_option("PSI4_CCT3", "CALC_TYPE", "CR-CC")
+        psi4.core.set_local_option("CCT3", "CALC_TYPE", "CR-CC")
     elif lowername == "ccsd_lct":  # CCSDt
-        psi4.core.set_local_option("PSI4_CCT3", "CALC_TYPE", "CCSD3A")
+        psi4.core.set_local_option("CCT3", "CALC_TYPE", "CCSD3A")
     elif lowername == "cc(t;3)":
-        psi4.core.set_local_option("PSI4_CCT3", "CALC_TYPE", "CCT3")
+        psi4.core.set_local_option("CCT3", "CALC_TYPE", "CCT3")
 
     # Compute a SCF reference, a wavefunction is return which holds the molecule used, orbitals
     # Fock matrices, and more
@@ -68,7 +68,7 @@ def run_cct3(name, **kwargs):
 
     # Call the Psi4 plugin
     # Please note that setting the reference wavefunction in this way is ONLY for plugins
-    cct3_wfn = psi4.core.plugin('psi4_cct3.so', ref_wfn)
+    cct3_wfn = psi4.core.plugin('cct3.so', ref_wfn)
 
     # Shove variables into global space
     for k, v in cct3_wfn.variables().items():
@@ -80,7 +80,7 @@ def run_cct3(name, **kwargs):
 
 
 # Integration with driver routines
-psi4.driver.procedures['energy']['psi4_cct3'] = run_cct3
+psi4.driver.procedures['energy']['cct3'] = run_cct3
 # CCSD is managed method. add `qc_module='cct3'` to access through this plugin
 psi4.driver.procedures['energy']['cr-cc(2,3)'] = run_cct3
 psi4.driver.procedures['energy']['ccsd_lct'] = run_cct3

--- a/pymodule.py
+++ b/pymodule.py
@@ -57,6 +57,10 @@ def run_cct3(name, **kwargs):
     # Please note that setting the reference wavefunction in this way is ONLY for plugins
     cct3_wfn = psi4.core.plugin('psi4_cct3.so', ref_wfn)
 
+    # Shove variables into global space
+    for k, v in cct3_wfn.variables().items():
+        psi4.core.set_variable(k, v)
+
     return cct3_wfn
 
 

--- a/src/cct3.cc
+++ b/src/cct3.cc
@@ -1,11 +1,11 @@
 /*
  * @BEGIN LICENSE
  *
- * moint by Psi4 Developer, a plugin to:
+ * psi4_cct3 by Emiliano Deustua, a plugin to:
  *
  * Psi4: an open-source quantum chemistry software package
  *
- * Copyright (c) 2007-2017 The Psi4 Developers.
+ * Copyright (c) 2007-2020 The Psi4 Developers.
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/src/cct3.cc
+++ b/src/cct3.cc
@@ -1,7 +1,7 @@
 /*
  * @BEGIN LICENSE
  *
- * psi4_cct3 by Emiliano Deustua, a plugin to:
+ * cct3 by Emiliano Deustua, a plugin to:
  *
  * Psi4: an open-source quantum chemistry software package
  *
@@ -52,7 +52,7 @@
 // This allows us to be lazy in getting the spaces in DPD calls
 #define ID(x) ints.DPD_ID(x)
 
-namespace psi{ namespace psi4_cct3{
+namespace psi{ namespace cct3{
 
 // Insertion sort algorithm adapted from HANDE and Rossetta
 void insertion_sort(double* sp_eigv, int* sp_ord, int* sp_ord_inv, int norbs) {
@@ -186,7 +186,7 @@ void F77NAME(print_psi4) (const char *string)
 extern "C" PSI_API
 int read_options(std::string name, Options &options)
 {
-    if (name == "PSI4_CCT3" || options.read_globals()) {
+    if (name == "CCT3" || options.read_globals()) {
         // [TODO] add shifts, diis control and rhf vs rohf
 
         /*- Number of frozen core molecular orbitals. -*/
@@ -219,7 +219,7 @@ int read_options(std::string name, Options &options)
 
 
 extern "C" PSI_API
-SharedWavefunction psi4_cct3(SharedWavefunction ref_wfn, Options& options)
+SharedWavefunction cct3(SharedWavefunction ref_wfn, Options& options)
 {
     // Definitions
     double ints_tol = 0.0;
@@ -411,6 +411,7 @@ SharedWavefunction psi4_cct3(SharedWavefunction ref_wfn, Options& options)
         eneprim = "CC(t;3)";
     }
 
+    ref_wfn->set_module("cct3");
     ref_wfn->set_scalar_variable("CURRENT CORRELATION ENERGY", corl_e);
     ref_wfn->set_energy(scf_e + corl_e);
     ref_wfn->set_scalar_variable(eneprim + " CORRELATION ENERGY", corl_e);

--- a/src/fortran.h
+++ b/src/fortran.h
@@ -64,11 +64,12 @@ extern "C" {
                     double *twobody,
                     double &erepul,
                     double &eref_psi4,
-                    double &rval
+                    double &eprim,
+                    double &esec
                     );
 };
 
-inline double do_cc(
+inline void do_cc(
                 int &froz,
                 int &socc,
                 int &docc,
@@ -84,10 +85,11 @@ inline double do_cc(
                 double *onebody,
                 double *twobody,
                 double &erepul,
-                double &eref_psi4
+                double &eref_psi4,
+                double &eprim,
+                double &esec
                 ){
 
-        double rval = 0.0;
         F77NAME(cc)(
                         froz,
                         socc,
@@ -105,8 +107,8 @@ inline double do_cc(
                         twobody,
                         erepul,
                         eref_psi4,
-                        rval
+                        eprim,
+                        esec
                         );
-        return rval;
 };
 #endif

--- a/src/fortran.h
+++ b/src/fortran.h
@@ -63,11 +63,12 @@ extern "C" {
                     double *onebody,
                     double *twobody,
                     double &erepul,
-                    double &eref_psi4
+                    double &eref_psi4,
+                    double &rval
                     );
 };
 
-inline void do_cc(
+inline double do_cc(
                 int &froz,
                 int &socc,
                 int &docc,
@@ -86,6 +87,7 @@ inline void do_cc(
                 double &eref_psi4
                 ){
 
+        double rval = 0.0;
         F77NAME(cc)(
                         froz,
                         socc,
@@ -102,7 +104,9 @@ inline void do_cc(
                         onebody,
                         twobody,
                         erepul,
-                        eref_psi4
+                        eref_psi4,
+                        rval
                         );
+        return rval;
 };
 #endif

--- a/src/wrapper_psi4.f90
+++ b/src/wrapper_psi4.f90
@@ -15,7 +15,8 @@ subroutine cc(&
         twobody, &
         erepul, &
         eref_psi4, &
-        rval)
+        eprim, &
+        esec)
 
     ! Wrapper between PSI4 and the CC(t;3) program. It handles molecular data,
     ! including one- and two-body integrals.
@@ -64,7 +65,7 @@ subroutine cc(&
     real(p), intent(in) :: twobody(orbs, orbs, orbs, orbs)
 
     real(p), intent(in) :: erepul, eref_psi4
-    real(p), intent(out) :: rval
+    real(p), intent(out) :: eprim, esec
     real(p) :: eref
     real(p) :: ccpq_energy(4)
 
@@ -126,9 +127,11 @@ subroutine cc(&
     call print_summary(erepul + eref, ecor, ccpq_energy, calc_type)
 
     if (calc_type == 2 .or. calc_type == 4) then
-        rval = ecor + ccpq_energy(4)
+        eprim = ecor + ccpq_energy(4)
+        esec = ecor
     else
-        rval = ecor
+        eprim = ecor
+        esec = ecor
     endif
 
 end subroutine cc

--- a/src/wrapper_psi4.f90
+++ b/src/wrapper_psi4.f90
@@ -14,7 +14,8 @@ subroutine cc(&
         onebody, &
         twobody, &
         erepul, &
-        eref_psi4)
+        eref_psi4, &
+        rval)
 
     ! Wrapper between PSI4 and the CC(t;3) program. It handles molecular data,
     ! including one- and two-body integrals.
@@ -63,6 +64,7 @@ subroutine cc(&
     real(p), intent(in) :: twobody(orbs, orbs, orbs, orbs)
 
     real(p), intent(in) :: erepul, eref_psi4
+    real(p), intent(out) :: rval
     real(p) :: eref
     real(p) :: ccpq_energy(4)
 
@@ -122,5 +124,11 @@ subroutine cc(&
 
 
     call print_summary(erepul + eref, ecor, ccpq_energy, calc_type)
+
+    if (calc_type == 2 .or. calc_type == 4) then
+        rval = ecor + ccpq_energy(4)
+    else
+        rval = ecor
+    endif
 
 end subroutine cc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+
+@pytest.fixture(scope="session", autouse=True)
+def set_up_overall(request):
+    import psi4
+    psi4.set_output_file("pytest_output.dat", False)
+    request.addfinalizer(tear_down)
+
+@pytest.fixture(scope="function", autouse=True)
+def set_up():
+    import psi4
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.set_output_file("pytest_output.dat", True)
+
+def tear_down():
+    import os
+    import glob
+    import psi4
+    psi4.core.close_outfile()
+    patterns = ['cavity.*', 'grid*', 'pytest_output.*h5',
+                'pytest_output.dat',
+                'pytest_output.*grad',
+                '*pcmsolver.inp', 'PEDRA.OUT*', 'timer.dat',
+                'FCIDUMP_SCF', 'FCIDUMP_MP2']
+    pytest_scratches = []
+    for pat in patterns:
+        pytest_scratches.extend(glob.glob(pat))
+    for fl in pytest_scratches:
+        try:
+            os.unlink(fl)
+        except (OSError, PermissionError):
+            pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ def tear_down():
                 'pytest_output.dat',
                 'pytest_output.*grad',
                 '*pcmsolver.inp', 'PEDRA.OUT*', 'timer.dat',
+                'hbar.bin', 'l_vec.bin', 'onebody.inp', 'PA', 'PB', 'PC','t_vec.bin', 'twobody.inp',
                 'FCIDUMP_SCF', 'FCIDUMP_MP2']
     pytest_scratches = []
     for pat in patterns:

--- a/tests/test_cct3.py
+++ b/tests/test_cct3.py
@@ -4,13 +4,17 @@ from psi4.tests.utils import compare_values
 import psi4_cct3
 
 
-@pytest.mark.parametrize("calc,eneprim,enesec", [
-    ("ccsd", "CCSD", "CCSD"),
-    ("cr-cc", "CR-CC(2,3)", "CCSD"),
-    ("ccsd3a", "CCSDt", "CCSDt"),
-    ("cct3", "CC(t;3)", "CCSDt"),
+@pytest.mark.parametrize("call,keyw,eneprim,enesec", [
+    ("ccsd", {"qc_module": "cct3"}, "CCSD", "CCSD"),
+    ("CR-cc(2,3)", {}, "CR-CC(2,3)", "CCSD"),
+    ("CCSD_lct", {}, "CCSDt", "CCSDt"),
+    ("CC(T;3)", {}, "CC(t;3)", "CCSDt"),
+    ("psi4_cct3", {"psi4_cct3__calc_type": "ccsd"}, "CCSD", "CCSD"),
+    ("psi4_cct3", {"psi4_cct3__calc_type": "cr-cc"}, "CR-CC(2,3)", "CCSD"),
+    ("psi4_cct3", {"psi4_cct3__calc_type": "ccsd3a"}, "CCSDt", "CCSDt"),
+    ("psi4_cct3", {"psi4_cct3__calc_type": "cct3"}, "CC(t;3)", "CCSDt"),
 ])
-def test_cct3_methods(calc, eneprim, enesec):
+def test_cct3_methods(call, keyw, eneprim, enesec):
     import psi4
     psi4.geometry("""
         units bohr
@@ -46,17 +50,11 @@ def test_cct3_methods(calc, eneprim, enesec):
         "psi4_cct3__act_occ": 1,
         "psi4_cct3__act_unocc": 1,
         "psi4_cct3__etol": 16,
-        "psi4_cct3__calc_type": calc,
         "basis": "anonymous1234",
     })
+    psi4.set_options(keyw)
 
-    #set {
-    #    e_convergence 11
-    #    d_convergence  10
-    #    r_convergence 10
-    #}
-
-    ene, wfn = psi4.energy("psi4_cct3", return_wfn=True)
+    ene, wfn = psi4.energy(call, return_wfn=True)
     psi4.core.print_variables()
     
     ref = {

--- a/tests/test_cct3.py
+++ b/tests/test_cct3.py
@@ -1,0 +1,116 @@
+import pytest
+
+from psi4.tests.utils import compare_values
+import psi4_cct3
+
+
+@pytest.mark.parametrize("calc,eneprim,enesec", [
+    ("ccsd", "CCSD", "CCSD"),
+    ("cr-cc", "CR-CC(2,3)", "CCSD"),
+    ("ccsd3a", "CCSDt", "CCSDt"),
+    ("cct3", "CC(t;3)", "CCSDt"),
+])
+def test_cct3_methods(calc, eneprim, enesec):
+    import psi4
+    psi4.geometry("""
+        units bohr
+        h -2.514213562373  -1.000000000000   0.000000000000
+        h -2.514213562373   1.000000000000   0.000000000000
+        h  2.514213562373  -1.000000000000   0.000000000000
+        h  2.514213562373   1.000000000000   0.000000000000
+        h -1.000000000000  -2.414213562373   0.000000000000
+        h -1.000000000000   2.414213562373   0.000000000000
+        h  1.000000000000  -2.414213562373   0.000000000000
+        h  1.000000000000   2.414213562373   0.000000000000
+        symmetry d2h
+    """)
+
+    def basisspec_psi4_yo__anonymous1234(mol, role):
+        bas = """
+            cartesian
+            ****
+            H   0
+            S   3  1.0000
+                  4.50038     0.0704800
+                  0.681277    0.407890
+                  0.151374    0.647670
+            ****
+        """
+        mol.set_basis_all_atoms("mbs_my", role=role)
+        return {"mbs_my": bas}
+
+    psi4.driver.qcdb.libmintsbasisset.basishorde["ANONYMOUS1234"] = basisspec_psi4_yo__anonymous1234
+
+    psi4.set_options({
+        "psi4_cct3__froz": 0,
+        "psi4_cct3__act_occ": 1,
+        "psi4_cct3__act_unocc": 1,
+        "psi4_cct3__etol": 16,
+        "psi4_cct3__calc_type": calc,
+        "basis": "anonymous1234",
+    })
+
+    #set {
+    #    e_convergence 11
+    #    d_convergence  10
+    #    r_convergence 10
+    #}
+
+    ene, wfn = psi4.energy("psi4_cct3", return_wfn=True)
+    psi4.core.print_variables()
+    
+    ref = {
+        "total": {
+            "HF":         -4.093745312228,
+            "CCSD":       -4.216648883330,
+            "CR-CC(2,3)": -4.219314222609,
+            "CCSDt":      -4.220106352850,
+            "CC(t;3)":    -4.220587742726,
+        },
+        "corl": {
+            "CCSD":       -0.122903571102,
+            "CR-CC(2,3)": -0.125568910381,
+            "CCSDt":      -0.126361040622,
+            "CC(t;3)":    -0.126842430498,
+        },
+    }
+
+    atol = 10
+    
+    for item in [
+        wfn.variable("current reference energy"),
+        psi4.core.variable("current reference energy"),
+        wfn.variable("hf total energy"),
+        psi4.core.variable("hf total energy"),
+    ]:
+        assert compare_values(ref["total"]["HF"], item, atol, "HF energy")
+    
+    for item in [
+        wfn.energy(),
+        wfn.variable("current energy"),
+        psi4.core.variable("current energy"),
+        wfn.variable(f"{eneprim} total energy"),
+        psi4.core.variable(f"{eneprim} total energy"),
+        ene,
+    ]:
+        assert compare_values(ref["total"][eneprim], item, atol, f"{eneprim} energy")
+    
+    for item in [
+        wfn.variable("current correlation energy"),
+        psi4.core.variable("current correlation energy"),
+        wfn.variable(f"{eneprim} correlation energy"),
+        psi4.core.variable(f"{eneprim} correlation energy"),
+    ]:
+        assert compare_values(ref["corl"][eneprim], item, atol, f"{eneprim} corl energy")
+    
+    for item in [
+        wfn.variable(f"{enesec} total energy"),
+        psi4.core.variable(f"{enesec} total energy"),
+    ]:
+        assert compare_values(ref["total"][enesec], item, atol, f"{enesec} energy")
+    
+    for item in [
+        wfn.variable(f"{enesec} correlation energy"),
+        psi4.core.variable(f"{enesec} correlation energy"),
+    ]:
+        assert compare_values(ref["corl"][enesec], item, atol, f"{enesec} corl energy")

--- a/tests/test_cct3.py
+++ b/tests/test_cct3.py
@@ -1,7 +1,7 @@
 import pytest
 
 from psi4.tests.utils import compare_values
-import psi4_cct3
+import cct3
 
 
 @pytest.mark.parametrize("call,keyw,eneprim,enesec", [
@@ -9,10 +9,10 @@ import psi4_cct3
     ("CR-cc(2,3)", {}, "CR-CC(2,3)", "CCSD"),
     ("CCSD_lct", {}, "CCSDt", "CCSDt"),
     ("CC(T;3)", {}, "CC(t;3)", "CCSDt"),
-    ("psi4_cct3", {"psi4_cct3__calc_type": "ccsd"}, "CCSD", "CCSD"),
-    ("psi4_cct3", {"psi4_cct3__calc_type": "cr-cc"}, "CR-CC(2,3)", "CCSD"),
-    ("psi4_cct3", {"psi4_cct3__calc_type": "ccsd3a"}, "CCSDt", "CCSDt"),
-    ("psi4_cct3", {"psi4_cct3__calc_type": "cct3"}, "CC(t;3)", "CCSDt"),
+    ("cct3", {"cct3__calc_type": "ccsd"}, "CCSD", "CCSD"),
+    ("cct3", {"cct3__calc_type": "cr-cc"}, "CR-CC(2,3)", "CCSD"),
+    ("cct3", {"cct3__calc_type": "ccsd3a"}, "CCSDt", "CCSDt"),
+    ("cct3", {"cct3__calc_type": "cct3"}, "CC(t;3)", "CCSDt"),
 ])
 def test_cct3_methods(call, keyw, eneprim, enesec):
     import psi4
@@ -46,10 +46,10 @@ def test_cct3_methods(call, keyw, eneprim, enesec):
     psi4.driver.qcdb.libmintsbasisset.basishorde["ANONYMOUS1234"] = basisspec_psi4_yo__anonymous1234
 
     psi4.set_options({
-        "psi4_cct3__froz": 0,
-        "psi4_cct3__act_occ": 1,
-        "psi4_cct3__act_unocc": 1,
-        "psi4_cct3__etol": 16,
+        "cct3__froz": 0,
+        "cct3__act_occ": 1,
+        "cct3__act_unocc": 1,
+        "cct3__etol": 16,
         "basis": "anonymous1234",
     })
     psi4.set_options(keyw)
@@ -112,3 +112,6 @@ def test_cct3_methods(call, keyw, eneprim, enesec):
         psi4.core.variable(f"{enesec} correlation energy"),
     ]:
         assert compare_values(ref["corl"][enesec], item, atol, f"{enesec} corl energy")
+
+    assert wfn.module() == "cct3"
+


### PR DESCRIPTION
This PR isn't finished, but I'm posting it for early warning. Glad to discuss concerns.

- [x] makes package installable observing `CMAKE_INSTALL_PREFIX` rather than in-source build and run. mostly a copy from v2rdm, which has been stable for a while
- [x] removes the `glob` commands in favor of explicit lists. there's a lot of files, but cmake can rebuild faster if it knows exactly what files it has to work on
- [x] adds `psi4_cct3Config.cmake` file so that plugin is findable via `find_package(psi4_cct3)`
- [x] a pattern for copyright and authorship on plugins has never been established, so feel free to adjust as you like. I mainly wanted to get rid of traces of the `moint` template.
- [x] pulled back the main correlation energy from Fortran
- [x] pull back the secondary correlation energy available for types 2 & 4
- [x] add pytest