### PR TITLE
Improve readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,8 @@ which improves the results obtained with the conventional CCSD(T) approach
 without resorting to any multireference concepts and being at most twice as
 expensive as CCSD(T) [8]_, [9]_, [10]_.
 
+Please note that UHF/UKS references are not supported by CCT3.
+
 Build
 -----
 
@@ -55,9 +57,10 @@ following lines:
 
    $ git clone https://github.com/piecuch-group/cct3
    $ cd cct3
-   $ `psi4 --plugin-compile`
+   $ `psi4 --plugin-compile` -DCMAKE_Fortran_FLAGS="-O3"
    $ make
-
+   $ make install
+   
 Once this step is done, you should have a working copy of the plugin. You can
 run a test example with:
 

--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,16 @@ first create a new python 3 environment and activate it via:
    $ conda create -n p4env python=3.7 psi4 psi4-dev -c psi4 -c psi4/label/dev
    $ source activate p4env
 
-Next, get the source code for the CC(t;3) plugin and compile it using the
-following lines:
+Next, get the source code for the CC(t;3) plugin and compile it.
+
+Compiling using the highest optimization level (-O3) is recommended for best
+performance, but the compiler may use large amounts of memory (16+ GiB) during the
+build.
+If that is a problem, lower optimization levels may be used, but the speed of the
+resulting CCT3 binary may suffer.
+
+If the machine has at least 32 GiB of RAM, you should have no problem executing
+the following lines:
 
 .. code-block:: bash
 


### PR DESCRIPTION
This PR fixes three issues in the readme. Fixes #6.

1. Note that UHF/UKS references are unsupported.
2. 50dda9c8d810ea078b7708123e679c7c8b41eda5 removed `-O3` from the build to allow the project to be built by CI. Unfortunately, this means that users following the instructions in the readme may be building their binaries with `-O0` or `-O1`. Building with `-O3` may require 16+ GiB of RAM, but the resulting binary is faster by a factor of ~3.
3. Instruct users to `make install`, otherwise the next step where they try to run the example will fail.